### PR TITLE
Add classes for lifting

### DIFF
--- a/src/Control/IxMonad/Aff/Class.purs
+++ b/src/Control/IxMonad/Aff/Class.purs
@@ -1,0 +1,12 @@
+module Control.IxMonad.Aff.Class where
+
+import Prelude
+
+import Control.IxMonad (class IxMonad)
+import Control.IxMonad.Aff (IxAff)
+
+class IxMonad m ⇐ IxMonadAff eff m | m → eff where
+  iliftAff ∷ ∀ i o a. IxAff eff i o a → m i o a
+
+instance ixMonadAffAff :: IxMonadAff eff (IxAff eff) where
+  iliftAff = id

--- a/src/Control/IxMonad/Eff/Class.purs
+++ b/src/Control/IxMonad/Eff/Class.purs
@@ -1,0 +1,12 @@
+module Control.IxMonad.Eff.Class where
+
+import Prelude
+
+import Control.IxMonad (class IxMonad)
+import Control.IxMonad.Eff (IxEff)
+
+class IxMonad m ⇐ IxMonadEff eff m | m → eff where
+  iliftEff ∷ ∀ i o a. IxEff eff i o a → m i o a
+
+instance ixMonadEffEff :: IxMonadEff eff (IxEff eff) where
+  iliftEff = id

--- a/src/Control/IxMonad/Trans/Class.purs
+++ b/src/Control/IxMonad/Trans/Class.purs
@@ -1,0 +1,6 @@
+module Control.IxMonad.Trans.Class where
+
+import Control.IxMonad (class IxMonad)
+
+class IxMonadTrans t where
+  ilift ∷ forall m i o a. IxMonad m ⇒ m i o a → t m i o a


### PR DESCRIPTION
@owickstrom I was going to add these, but I think there's some things to play with here, since you might not want to directly promote `i` and `o` while lifting, and instead re-map them to some composite index. Meaning we might need a definition more like this:

``` purescript
class IxMonadTrans t i o j p | i -> j, o -> p where
  ilift ∷ forall m a. IxMonad m ⇒ m i o a → t m j p a
```

But I also need to get back to work, so will have to experiment more later :smile: