### PR TITLE
Restrict index to only valid transitions

### DIFF
--- a/src/Control/Applicative/Indexed.purs
+++ b/src/Control/Applicative/Indexed.purs
@@ -8,14 +8,15 @@ module Control.Applicative.Indexed
 
 import Prelude (Unit, unit)
 import Control.Apply.Indexed
+import Control.ValidTransition (class ValidTransition)
 
 class IxApply m ⇐ IxApplicative m where
-  ipure ∷ ∀ a x. a → m x x a
+  ipure ∷ ∀ a x. ValidTransition x x ⇒ a → m x x a
 
-iwhen ∷ ∀ m x. IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
+iwhen ∷ ∀ m x. ValidTransition x x ⇒ IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
 iwhen true m = m
 iwhen false _ = ipure unit
 
-iunless ∷ ∀ m x. IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
+iunless ∷ ∀ m x. ValidTransition x x ⇒ IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
 iunless false m = m
 iunless true _ = ipure unit

--- a/src/Control/Apply/Indexed.purs
+++ b/src/Control/Apply/Indexed.purs
@@ -6,18 +6,19 @@ module Control.Apply.Indexed
   , module Data.Functor.Indexed
   ) where
 
-import Prelude (const, identity)
 import Data.Functor.Indexed
+import Control.ValidTransition (class ValidTransition)
+import Prelude (const, identity)
 
 class IxFunctor m ⇐ IxApply m where
-  iapply ∷ ∀ a b x y z. m x y (a → b) → m y z a → m x z b
+  iapply ∷ ∀ a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ m x y (a → b) → m y z a → m x z b
 
-iapplyFirst ∷ ∀ m a b x y z. IxApply m ⇒ m x y a → m y z b → m x z a
+iapplyFirst ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxApply m ⇒ m x y a → m y z b → m x z a
 iapplyFirst a b = const `imap` a `iapply` b
 
 infixl 4 iapplyFirst as <*:
 
-iapplySecond ∷ ∀ m a b x y z. IxApply m => m x y a -> m y z b -> m x z b
+iapplySecond ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxApply m => m x y a -> m y z b -> m x z b
 iapplySecond a b = const identity `imap` a `iapply` b
 
 infixl 4 iapplySecond as :*>

--- a/src/Control/Bind/Indexed.purs
+++ b/src/Control/Bind/Indexed.purs
@@ -11,32 +11,33 @@ module Control.Bind.Indexed
 
 import Prelude (flip, identity, Unit)
 import Control.Apply.Indexed
+import Control.ValidTransition (class ValidTransition)
 
 class IxApply m ⇐ IxBind m where
-  ibind ∷ ∀ a b x y z. m x y a → (a → m y z b) → m x z b
+  ibind ∷ ∀ a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ m x y a → (a → m y z b) → m x z b
 
 infixl 1 ibind as :>>=
 
-ibindFlipped ∷ ∀ m a b x y z. IxBind m ⇒ (a → m y z b) → m x y a → m x z b
+ibindFlipped ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m ⇒ (a → m y z b) → m x y a → m x z b
 ibindFlipped = flip ibind
 
 infixr 1 ibindFlipped as =<<:
 
-ijoin ∷ forall m z y x a. IxBind m => m x y (m y z a) -> m x z a
+ijoin ∷ forall m z y x a. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m => m x y (m y z a) -> m x z a
 ijoin m = m :>>= identity
 
-composeiKleisli ∷ ∀ m a b c x y z. IxBind m ⇒ (a → m x y b) → (b → m y z c) → a → m x z c
+composeiKleisli ∷ ∀ m a b c x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m ⇒ (a → m x y b) → (b → m y z c) → a → m x z c
 composeiKleisli f g a = f a :>>= g
 
 infixr 1 composeiKleisli as :>=>
 
-composeiKleisliFlipped ∷ ∀ m a b c x y z. IxBind m ⇒ (b → m y z c) → (a → m x y b) → a → m x z c
+composeiKleisliFlipped ∷ ∀ m a b c x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m ⇒ (b → m y z c) → (a → m x y b) → a → m x z c
 composeiKleisliFlipped f g a = f =<<: g a
 
 infixr 1 composeiKleisliFlipped as <=<:
 
 class IxDiscard a where
-  idiscard ∷ ∀ f b x y z. IxBind f ⇒ f x y a → (a → f y z b) → f x z b
+  idiscard ∷ ∀ f b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind f ⇒ f x y a → (a → f y z b) → f x z b
 
 instance ixDiscardUnit :: IxDiscard Unit where
   idiscard = ibind

--- a/src/Control/Monad/Indexed.purs
+++ b/src/Control/Monad/Indexed.purs
@@ -14,20 +14,16 @@ import Prelude
 import Control.Applicative.Indexed (class IxApplicative, ipure, iwhen, iunless)
 import Control.Apply.Indexed (class IxApply, iapply, iapplyFirst, iapplySecond, (:*>), (<*:))
 import Control.Bind.Indexed (class IxBind, ibind, (:>>=), ibindFlipped, (=<<:), composeiKleisli, (:>=>), composeiKleisliFlipped, (<=<:))
+import Control.ValidTransition (class ValidTransition)
 import Data.Functor.Indexed (class IxFunctor, imap, ivoid, ivoidLeft, ivoidRight, (:$>), (<$:))
 
 class (IxApplicative m, IxBind m) ⇐ IxMonad m
 
-iap ∷ ∀ m a b x y z. IxMonad m ⇒ m x y (a → b) → m y z a → m x z b
-iap f a = do
-  f' ← f
-  a' ← a
-  ipure (f' a')
-  where
-    bind = ibind
+iap ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ ValidTransition z z ⇒ IxMonad m ⇒ m x y (a → b) → m y z a → m x z b
+iap f a = f :>>= \f' -> a :>>= \a' -> ipure (f' a')
 
-iwhenM ∷ ∀ m x y. IxMonad m ⇒ m x y Boolean → m y y Unit → m x y Unit
+iwhenM ∷ ∀ m x y. ValidTransition x y ⇒ ValidTransition y y ⇒ IxMonad m ⇒ m x y Boolean → m y y Unit → m x y Unit
 iwhenM mb m = mb :>>= \b → iwhen b m
 
-iunlessM ∷ ∀ m x y. IxMonad m ⇒ m x y Boolean → m y y Unit → m x y Unit
+iunlessM ∷ ∀ m x y. ValidTransition x y ⇒ ValidTransition y y ⇒ IxMonad m ⇒ m x y Boolean → m y y Unit → m x y Unit
 iunlessM mb m = mb :>>= \b → iunless b m

--- a/src/Control/Monad/Qualified.purs
+++ b/src/Control/Monad/Qualified.purs
@@ -25,19 +25,20 @@ import Data.Functor.Indexed (class IxFunctor, imap)
 import Control.Apply.Indexed (class IxApply, iapply)
 import Control.Applicative.Indexed (class IxApplicative, ipure)
 import Control.Bind.Indexed (class IxBind, ibind, class IxDiscard, idiscard)
-import Control.Monad.Indexed (class IxMonad)
+import Control.ValidTransition (class ValidTransition)
 
-map ∷ ∀ f a b x y. IxFunctor f => (a → b) → f x y a → f x y b
+map ∷ ∀ f a b x y. ValidTransition x y ⇒ IxFunctor f ⇒ (a → b) → f x y a → f x y b
 map = imap
 
-apply ∷ ∀ m a b x y z. IxApply m => m x y (a → b) → m y z a → m x z b
+apply ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxApply m ⇒ m x y (a → b) → m y z a → m x z b
 apply = iapply
 
-pure ∷ ∀ m a x. IxApplicative m => a → m x x a
+pure ∷ ∀ m a x. ValidTransition x x ⇒ IxApplicative m ⇒ a → m x x a
 pure = ipure
 
-bind ∷ ∀ m a b x y z. IxMonad m => m x y a → (a → m y z b) → m x z b
+bind ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m ⇒ m x y a → (a → m y z b) → m x z b
 bind = ibind
 
-discard ∷ ∀ m a b x y z. IxBind m => IxDiscard a => m x y a → (a → m y z b) → m x z b
+
+discard ∷ ∀ m a b x y z. ValidTransition x y ⇒ ValidTransition y z ⇒ IxBind m ⇒ IxDiscard a ⇒ m x y a → (a → m y z b) → m x z b
 discard = idiscard

--- a/src/Control/ValidTransition.purs
+++ b/src/Control/ValidTransition.purs
@@ -3,3 +3,5 @@ module Control.ValidTransition where
 -- | A type class for defining a valid state transition in
 -- | `IxFunctor`, `IxApply`, `IxApplicative`, `IxBind`, and `IxMonad`
 class ValidTransition x y
+
+instance validTransitionSelfToSelf :: ValidTransition self self

--- a/src/Control/ValidTransition.purs
+++ b/src/Control/ValidTransition.purs
@@ -1,0 +1,5 @@
+module Control.ValidTransition where
+
+-- | A type class for defining a valid state transition in
+-- | `IxFunctor`, `IxApply`, `IxApplicative`, `IxBind`, and `IxMonad`
+class ValidTransition x y

--- a/src/Data/Functor/Indexed.purs
+++ b/src/Data/Functor/Indexed.purs
@@ -1,19 +1,20 @@
 module Data.Functor.Indexed where
 
+import Control.ValidTransition (class ValidTransition)
 import Prelude
 
 class IxFunctor f where
-  imap ∷ ∀ a b x y. (a → b) → f x y a → f x y b
+  imap ∷ ∀ a b x y. ValidTransition x y ⇒ (a → b) → f x y a → f x y b
 
-ivoid ∷ ∀ f a x y. IxFunctor f ⇒ f x y a → f x y Unit
+ivoid ∷ ∀ f a x y. ValidTransition x y ⇒ IxFunctor f ⇒ f x y a → f x y Unit
 ivoid = imap (const unit)
 
-ivoidRight ∷ ∀ f a b x y. IxFunctor f ⇒ a → f x y b → f x y a
+ivoidRight ∷ ∀ f a b x y. ValidTransition x y ⇒ IxFunctor f ⇒ a → f x y b → f x y a
 ivoidRight x = imap (const x)
 
 infixl 4 ivoidRight as <$:
 
-ivoidLeft ∷ ∀ f a b x y. IxFunctor f ⇒ f x y a → b → f x y b
+ivoidLeft ∷ ∀ f a b x y. ValidTransition x y ⇒ IxFunctor f ⇒ f x y a → b → f x y b
 ivoidLeft f x = imap (const x) f
 
 infixl 4 ivoidLeft as :$>


### PR DESCRIPTION
I doubt this is desirable, but thought it might lead to an interesting discussion.

While using this library for `hyper`, I discovered that one could subjugate the index change by defining a type signature that resets the index to a prior state. The code will compile since there is nothing restricting what this state change can be. As a result, the guarantees of this library are completely broken.
```purescript
import Control.Monad.Index.Qualified as Ix

streetLight :: m Green Red a
streetLight = Ix.do
  greenLight
  yellowLight
  redLight
  noCarCrash

-- user function
lightIsGreenAgain :: m Yellow Green Unit
lightIsGreenAgain = -- implementation

streetLight :: m Green Green a
streetLight = Ix.do
  greenLight
  yellowLight
  lightIsGreenAgain
  carCrash
```

To fix this, I include a `ValidTransition` type class. The empty dictionary will be erased before runtime due to the recent work in the compiler. Thus, a library could define instances for their domain type that define valid index transitions in their types. If used with kinds, this would make the index more understandable. However, due to the open-natured of kinds, I'm not sure whether this truly fixes the problem.
The other tradeoff is higher type-safety at the cost of increased verbosity.