### PR TITLE
Makes ipure x y instead of x x

### DIFF
--- a/src/Control/Applicative/Indexed.purs
+++ b/src/Control/Applicative/Indexed.purs
@@ -11,12 +11,12 @@ import Control.Apply.Indexed
 
 class IxApplicative :: forall k. (k -> k -> Type -> Type) -> Constraint
 class IxApply m ⇐ IxApplicative m where
-  ipure ∷ ∀ a x. a → m x x a
+  ipure ∷ ∀ a x y. a → m x y a
 
-iwhen ∷ ∀ m x. IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
+iwhen ∷ ∀ m x y. IxApplicative m ⇒ Boolean → m x y Unit → m x y Unit
 iwhen true m = m
 iwhen false _ = ipure unit
 
-iunless ∷ ∀ m x. IxApplicative m ⇒ Boolean → m x x Unit → m x x Unit
+iunless ∷ ∀ m x y. IxApplicative m ⇒ Boolean → m x y Unit → m x y Unit
 iunless false m = m
 iunless true _ = ipure unit


### PR DESCRIPTION
I think (hope) this is legal - there seems to be precedent elsewhere for this: https://gist.github.com/gaku-sei/434d4de22dd66402728542cb9c3c7d35#file-indexedburger-re-L19. If this is swingable, it may solve a couple small issues in our codebase.